### PR TITLE
Remove no-op context manager for executable in hatanaka.py

### DIFF
--- a/hatanaka/hatanaka.py
+++ b/hatanaka/hatanaka.py
@@ -146,5 +146,5 @@ executables = importlib_resources.files(hatanaka.bin)
 def _popen(program, args, **kwargs):
     if platform.system() == 'Windows':
         program += '.exe'
-    with executables.joinpath(program) as executable:
-        return subprocess.Popen([str(executable)] + args, **kwargs)
+    executable = executables.joinpath(program)
+    return subprocess.Popen([str(executable)] + args, **kwargs)


### PR DESCRIPTION
While using Hatanaka 2.8.0 (via GeoRinex 1.16.1) with Python 3.11 on Fedora 37, I'm seeing lots of warnings like
```
/home/wball/.local/lib/python3.11/site-packages/hatanaka/hatanaka.py:149: DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
  with executables.joinpath(program) as executable:
```
Indeed, the use of `pathlib.Path` as a context manager is ready for deprecation ([see discussion here](https://bugs.python.org/issue39682)). 

This is a small change to replace the soon-to-be-deprecated context manager by assigning the variable, which at least removes the DeprecationWarning for me.