### PR TITLE
Fix buffer underrun in read_chk_line for empty line

### DIFF
--- a/rnxcmp/source/crx2rnx.c
+++ b/rnxcmp/source/crx2rnx.c
@@ -769,8 +769,7 @@ int  read_chk_line(char *line){
             return 1;
         }
     }
-    if( *(p-1) == '\n' )p--;
-    if( *(p-1) == '\r' )p--;   /*** check DOS CR/LF ***/
+    if( p != line && *(p-1) == '\r' )p--;   /*** check DOS CR/LF ***/
     *p = '\0';
     return 0;
 }


### PR DESCRIPTION
Also remove redundant condition. We do p = strchr(line, '\n') which looks for the
first '\n', so *(p -1) can never be '\n'