### PR TITLE
Fix out of bounds array access

### DIFF
--- a/rnxcmp/source/crx2rnx.c
+++ b/rnxcmp/source/crx2rnx.c
@@ -213,7 +213,10 @@ int main(int argc, char *argv[]){
         read_clock(dline,clk1.u,clk1.l);
         for(i=0,i0=sattbl ; i<nsat ; i++,i0++){
             ntype = ntype_record[i];
-            if( getdiff(dy1[i],dy0[*i0],*i0,dflag[i]) != 0 ) {skip_to_next(dline);goto SKIP;}
+            if( getdiff(dy1[i],*i0 != -1 ? dy0[*i0] : NULL,*i0,dflag[i]) != 0 ) {
+                skip_to_next(dline);
+                goto SKIP;
+            }
         }
 
         /*************************************/


### PR DESCRIPTION
dy0[*i0] is undefined behavior if *i0 == -1. We don't actually use the value in `getdiff` in that case, so pass NULL instead.